### PR TITLE
Fix right edge scroll on retina displays

### DIFF
--- a/Source/Headers/input.h
+++ b/Source/Headers/input.h
@@ -86,6 +86,7 @@ void InitInput(void);
 void ReadKeyboard(void);
 
 OGLPoint2D GetLogicalMouseCoord(void);
+void GetMousePixelCoord(int *x, int *y);
 
 void DoSDLMaintenance(void);
 Boolean GetKeyState(uint16_t sdlScancode);

--- a/Source/System/Areas/Shootout.c
+++ b/Source/System/Areas/Shootout.c
@@ -489,7 +489,7 @@ Boolean	allowRot;
 
 	int windowX = 0;
 	int windowY = 0;
-	SDL_GetMouseState(&windowX, &windowY);
+    GetMousePixelCoord(&windowX, &windowY);
 
 			/* XHAIRS COORDS ARE IN LOGICAL 2D SPACE */
 

--- a/Source/System/SDLInput.c
+++ b/Source/System/SDLInput.c
@@ -205,6 +205,19 @@ OGLPoint2D GetLogicalMouseCoord(void)
 {
 	int windowX = 0;
 	int windowY = 0;
+	GetMousePixelCoord(&windowX, &windowY);
+	OGLPoint2D windowPt =
+	{
+		0.5f + (float) windowX,
+		0.5f + (float) windowY
+	};
+
+	return WindowPointToLogical(windowPt);
+}
+
+void GetMousePixelCoord(int *x, int *y) {
+	int windowX = 0;
+	int windowY = 0;
 	SDL_GetMouseState(&windowX, &windowY);
 
 	// On macOS, the mouse position is relative to the window's "point size" on Retina screens.
@@ -214,13 +227,8 @@ OGLPoint2D GetLogicalMouseCoord(void)
 	float dpiScaleX = (float) gGameWindowWidth / (float) windowW;		// gGameWindowWidth is in actual pixels
 	float dpiScaleY = (float) gGameWindowHeight / (float) windowH;		// gGameWindowHeight is in actual pixels
 
-	OGLPoint2D windowPt =
-	{
-		0.5f + (float) windowX * dpiScaleX,
-		0.5f + (float) windowY * dpiScaleY
-	};
-
-	return WindowPointToLogical(windowPt);
+	*x = (int) ((float) windowX * dpiScaleX);
+	*y = (int) ((float) windowY * dpiScaleY);
 }
 
 /**********************/


### PR DESCRIPTION
Fixes crosshair scrolling of the right edge during shootout on retina displays. 

The problem was that `SDL_GetMouseState()` returns mouse coordinates in _points_ while `gGameWindowWidth` and `gGameWindowHeight` contain the window size in _pixels_. So when moving the crosshair to the right edge, the X mouse position on my retina screen was `2560` (-1) while `gGameWindowWidth` was `5120`.

Because of that, scrolling from the right edge was impossible but from the left still worked (although not as precise as expected).

Thank you very much, @jorio for reviving yet another one of the legendary Pangeasoft games back from the classical Mac gaming era, awesome job! ❤️